### PR TITLE
Add arguments info to controller multimethods docs

### DIFF
--- a/src/keechma/next/controller.cljs
+++ b/src/keechma/next/controller.cljs
@@ -15,39 +15,57 @@
     :keechma.controller/wrap-transaction))
 
 (defmulti prep
-  "Prep is called once when the app is started (for each controller). It will receive the controller map as it's only argument. It should return a new controller config. This allows you to prep the map for all controller instances that could be created during the app's lifetime."
+  "Prep is called once when the app is started (for each controller). It will receive the controller map as it's only argument. It should return a new controller config. This allows you to prep the map for all controller instances that could be created during the app's lifetime.
+
+  Arguments: [controller]"
   controller-dispatcher)
 
 (defmulti params
-  "Params is called before controller is started. It can be used to validate or process value returned from the `:keechma.controller/params` key in the application map. It will receive the controller map (as returned from the `keechma.next.controller/prep` function) and params as the arguments. This function will be called only if the value returned from `:keecma.controller/params` is truthy. If this function returns a falsy value, the controller will not be started."
+  "Params is called before controller is started. It can be used to validate or process value returned from the `:keechma.controller/params` key in the application map. It will receive the controller map (as returned from the `keechma.next.controller/prep` function) and params as the arguments. This function will be called only if the value returned from `:keecma.controller/params` is truthy. If this function returns a falsy value, the controller will not be started.
+
+  Arguments: [controller params]"
   controller-dispatcher)
 
 (defmulti init
-  "Called before the controller is started (for each instance of controller, unlike prep). It will receive a controller map as it's only argument. This map will contain controller's config and will be passed to all controller functions as the first argument. This function should return a new controller config. This is a place where you can setup any stateful processes that will be used by the controller. For instance if you want to use `go-loop` to handle commands sent to controller, this is a place where you would create the incoming channel"
+  "Called before the controller is started (for each instance of controller, unlike prep). It will receive a controller map as it's only argument. This map will contain controller's config and will be passed to all controller functions as the first argument. This function should return a new controller config. This is a place where you can setup any stateful processes that will be used by the controller. For instance if you want to use `go-loop` to handle commands sent to controller, this is a place where you would create the incoming channel.
+
+  Arguments: [controller]"
   controller-dispatcher)
 
 (defmulti api
-  "Called after `init` and before `start`. This function can expose an object that will be passed as a first argument to the API calls. API calls are not wrapped in the transact block automatically."
+  "Called after `init` and before `start`. This function can expose an object that will be passed as a first argument to the API calls. API calls are not wrapped in the transact block automatically.
+
+  Arguments: [controller]"
   controller-dispatcher)
 
 (defmulti terminate
-  "Called on the controller shutdown (after stop). This function is used to cleanup any resources created in the `init` method. This function is used for side-effects and it's return value is ignored."
+  "Called on the controller shutdown (after stop). This function is used to cleanup any resources created in the `init` method. This function is used for side-effects and it's return value is ignored.
+
+  Arguments: [controller]"
   controller-dispatcher)
 
 (defmulti start
-  "Called once on the controller start. This function will receive the controller config map and a previous state and should return the initial state synchronously."
+  "Called once on the controller start. This function will receive the controller config map and a previous state and should return the initial state synchronously.
+
+  Arguments: [controller params deps-state prev-state]"
   controller-dispatcher)
 
 (defmulti stop
-  "Called once when the controller is stopped. This function will receive the controller config map and the current state and should return the final state. This allows you to preserve any state (if you need to) while the controller is not running. This state will not be visible to any descendants or subscriptions. State returned from the stop function will be passed to the _next_ instance's start function (as the fourth argument)"
+  "Called once when the controller is stopped. This function will receive the controller config map and the current state and should return the final state. This allows you to preserve any state (if you need to) while the controller is not running. This state will not be visible to any descendants or subscriptions. State returned from the stop function will be passed to the _next_ instance's start function (as the fourth argument).
+
+  Arguments: [controller params state deps-state]"
   controller-dispatcher)
 
 (defmulti handle
-  "Called whenever an event is sent to the controller. It receives the controller config map, the command and the command payload as arguments. There is a good possibility that the controller will receive an event it's not handling, so make sure to properly manage this case. Other controllers and UIs can dispatch or broadcast events, and there is no way of knowing if a particular controller handles a particular event."
+  "Called whenever an event is sent to the controller. It receives the controller config map, the command and the command payload as arguments. There is a good possibility that the controller will receive an event it's not handling, so make sure to properly manage this case. Other controllers and UIs can dispatch or broadcast events, and there is no way of knowing if a particular controller handles a particular event.
+
+  Arguments: [controller event payload]"
   transacted-controller-dispatcher)
 
 (defmulti derive-state
-  "This function is called whenever the controller's internal state is changed, or whenever the public state of any of the ancestor controller states is changes. Use this function to calculate the controller's public state. Public state is visible to the subscriptions and other controllers that depend on the controller. It will receive controller's internal state and a map with the states of ancestors. Use this function to derive the state if needed. All descendants and subscriptions will receive the returned value as a payload on the controller's key whenever the value changes"
+  "This function is called whenever the controller's internal state is changed, or whenever the public state of any of the ancestor controller states is changes. Use this function to calculate the controller's public state. Public state is visible to the subscriptions and other controllers that depend on the controller. It will receive controller's internal state and a map with the states of ancestors. Use this function to derive the state if needed. All descendants and subscriptions will receive the returned value as a payload on the controller's key whenever the value changes.
+
+  Arguments: [controller state deps-state]"
   controller-dispatcher)
 
 (defmethod prep :default [controller]


### PR DESCRIPTION
Add arguments info to controller multimethods docs.
Tested in Calva, arguments are now visible in description (empty line in docs is to throw args in new line).